### PR TITLE
LIME-34-Map Experian code U015 to CI test

### DIFF
--- a/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import gov.di_ipv_fraud.service.ConfigurationService;
 import gov.di_ipv_fraud.utilities.Driver;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -19,6 +20,7 @@ import java.util.logging.Logger;
 
 import static gov.di_ipv_fraud.pages.Headers.CHECKING_YOUR_DETAILS;
 import static gov.di_ipv_fraud.pages.Headers.IPV_CORE_STUB;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -328,8 +330,12 @@ public class FraudPageObject extends UniversalSteps {
                 new ObjectMapper().readerFor(new TypeReference<List<String>>() {});
         List<String> cis = listReader.readValue(cisNode);
 
-        if (cis.size() > 0) {
-            assertTrue(cis.contains(ci));
+        if (StringUtils.isNotEmpty(ci)) {
+            if (cis.size() > 0) {
+                assertTrue(cis.contains(ci));
+            } else {
+                fail("No CIs found");
+            }
         }
     }
 

--- a/src/test/resources/features/FraudCRI.feature
+++ b/src/test/resources/features/FraudCRI.feature
@@ -250,11 +250,32 @@ Feature: Fraud CRI
     And JSON payload should contain ci A01 and score 2
     And The test is complete and I close the driver
 
-
+  # User with surname CI6 will return the U015 code and will return CI as P01 in the VC
   @pep_test_all_users @build
   Scenario Outline: Edit User Happy Path with pep CI (STUB)
     Given I navigate to the IPV Core Stub
     And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    And I am on Edit User page
+    And I clear existing Date of Birth
+    And I enter Date of birth as <dob>
+    And I clear existing first name
+    And I clear existing surname
+    And I enter name <name>
+    And I submit user updates
+    And I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+
+    Examples:
+      | name            | dob            | ci  | score |
+      | ANTHONY CI6     | 17/02/1963     | P01 |    2  |
+
+  @pep_test_all_users @staging
+  Scenario Outline: Edit User Happy Path with pep CI (STUB)
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Staging environment
     And I search for user name LINDA DUFF in the Experian table
     When I click on Edit User link
     And I am on Edit User page


### PR DESCRIPTION
Adding a test to check that User with surname CI6 will return the U015 code and will have the CI P01 in the VC.
This test is to be run on the build environment.
This pull request also has the changes to the method that checks for the CI in the JSON response.

Changes have been made to the following :
src/test/resources/features/FraudCRI.feature
src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java