### PR TITLE
Add automation test for Lime-116-Add endpoint to IPV Core stub to all…

### DIFF
--- a/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
@@ -1,0 +1,132 @@
+package gov.di_ipv_fraud.step_definitions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.di_ipv_fraud.pages.FraudPageObject;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FraudAPIStepDefs {
+    private static String SESSION_REQUEST_BODY;
+    private static String SESSION_ID;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final int LindaDuffExperianRowNumber = 6;
+    private static final Logger LOGGER = Logger.getLogger(FraudPageObject.class.getName());
+
+    private String getPrivateAPIEndpoint(){
+        String privateAPIEndpoint = System.getenv("apiGatewayIdPrivate");
+        if (privateAPIEndpoint == null) {
+            throw new IllegalArgumentException("Environment variable PRIVATE API endpoint is not set");
+        }
+        LOGGER.info("privateAPIEndpoint =>"+privateAPIEndpoint);
+        return  "https://" + privateAPIEndpoint + ".execute-api.eu-west-2.amazonaws.com/build";
+    }
+
+    @Given("user has the user identity in the form of a signed JWT string")
+    public void user_has_the_user_identity_in_the_form_of_a_signed_jwt_string()
+            throws URISyntaxException, IOException, InterruptedException {
+        String coreStubUrl = System.getenv("coreStubUrl");
+        LOGGER.info("STUB URL = "+coreStubUrl);
+        if (coreStubUrl == null) {
+            throw new IllegalArgumentException("Environment variable IPV_CORE_STUB_URL is not set");
+        }
+
+        String jsonString =
+                getClaimsForUser(
+                        coreStubUrl, "fraud-cri-build", LindaDuffExperianRowNumber);
+        SESSION_REQUEST_BODY = createRequest(coreStubUrl, "fraud-cri-build", jsonString);
+        LOGGER.info("SESSION_REQUEST_BODY = " + SESSION_REQUEST_BODY);
+    }
+
+    private String getClaimsForUser(String baseUrl, String criId, int userDataRowNumber)
+            throws URISyntaxException, IOException, InterruptedException {
+        var url = new URI(
+                baseUrl
+                        + "backend/generateInitialClaimsSet?cri="
+                        + criId
+                        + "&rowNumber="
+                        + userDataRowNumber);
+
+        LOGGER.info("URL =>> " + url);
+
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                url)
+                        .GET()
+                        .setHeader("Authorization", getBasicAuthenticationHeader(System.getenv("coreStubUsername"), System.getenv("coreStubPassword")))
+                        .build();
+        return sendHttpRequest(request).body();
+    }
+
+    private String createRequest(String baseUrl, String criId, String jsonString)
+            throws URISyntaxException, IOException, InterruptedException {
+
+        URI uri = new URI(baseUrl + "backend/createSessionRequest?cri=" + criId);
+        LOGGER.info("jsonString = " + jsonString);
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(uri)
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .setHeader("Authorization", getBasicAuthenticationHeader(System.getenv("coreStubUsername"), System.getenv("coreStubPassword")))
+                        .POST(HttpRequest.BodyPublishers.ofString(jsonString))
+                        .build();
+
+        return sendHttpRequest(request).body();
+    }
+
+    @When("user sends a POST request to session end point")
+    public void user_sends_a_post_request_to_session_end_point()
+            throws IOException, InterruptedException {
+        // Write code here that turns the phrase above into concrete actions
+        LOGGER.info("getPrivateAPIEndpoint() ==> "+ getPrivateAPIEndpoint());
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(getPrivateAPIEndpoint() + "/session"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+//                        .setHeader("X-Forwarded-For", "192.168.0.1")
+                        .POST(HttpRequest.BodyPublishers.ofString(SESSION_REQUEST_BODY))
+                        .build();
+        String sessionResponse = sendHttpRequest(request).body();
+        LOGGER.info("sessionResponse = " + sessionResponse);
+        Map<String, String> deserialisedResponse =
+                objectMapper.readValue(sessionResponse, new TypeReference<>() {
+                });
+        SESSION_ID = deserialisedResponse.get("session_id");
+    }
+
+    @Then("user gets a session-id")
+    public void user_gets_a_session_id() {
+        LOGGER.info("SESSION_ID = " + SESSION_ID);
+        assertTrue(StringUtils.isNotBlank(SESSION_ID));
+    }
+
+    private HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response;
+    }
+
+    private static final String getBasicAuthenticationHeader(String username, String password) {
+        String valueToEncode = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+    }
+
+}

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
@@ -25,16 +25,7 @@ public class FraudAPIStepDefs {
     private static String SESSION_ID;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final int LindaDuffExperianRowNumber = 6;
-    private static final Logger LOGGER = Logger.getLogger(FraudPageObject.class.getName());
-
-    private String getPrivateAPIEndpoint(){
-        String privateAPIEndpoint = System.getenv("apiGatewayIdPrivate");
-        if (privateAPIEndpoint == null) {
-            throw new IllegalArgumentException("Environment variable PRIVATE API endpoint is not set");
-        }
-        LOGGER.info("privateAPIEndpoint =>"+privateAPIEndpoint);
-        return  "https://" + privateAPIEndpoint + ".execute-api.eu-west-2.amazonaws.com/build";
-    }
+    private static final Logger LOGGER = Logger.getLogger(FraudAPIStepDefs.class.getName());
 
     @Given("user has the user identity in the form of a signed JWT string")
     public void user_has_the_user_identity_in_the_form_of_a_signed_jwt_string()
@@ -50,6 +41,42 @@ public class FraudAPIStepDefs {
                         coreStubUrl, "fraud-cri-build", LindaDuffExperianRowNumber);
         SESSION_REQUEST_BODY = createRequest(coreStubUrl, "fraud-cri-build", jsonString);
         LOGGER.info("SESSION_REQUEST_BODY = " + SESSION_REQUEST_BODY);
+    }
+
+    @When("user sends a POST request to session end point")
+    public void user_sends_a_post_request_to_session_end_point()
+            throws IOException, InterruptedException {
+        // Write code here that turns the phrase above into concrete actions
+        LOGGER.info("getPrivateAPIEndpoint() ==> "+ getPrivateAPIEndpoint());
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(getPrivateAPIEndpoint() + "/session"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+//                        .setHeader("X-Forwarded-For", "192.168.0.1")
+                        .POST(HttpRequest.BodyPublishers.ofString(SESSION_REQUEST_BODY))
+                        .build();
+        String sessionResponse = sendHttpRequest(request).body();
+        LOGGER.info("sessionResponse = " + sessionResponse);
+        Map<String, String> deserialisedResponse =
+                objectMapper.readValue(sessionResponse, new TypeReference<>() {
+                });
+        SESSION_ID = deserialisedResponse.get("session_id");
+    }
+
+    @Then("user gets a session-id")
+    public void user_gets_a_session_id() {
+        LOGGER.info("SESSION_ID = " + SESSION_ID);
+        assertTrue(StringUtils.isNotBlank(SESSION_ID));
+    }
+
+    private String getPrivateAPIEndpoint(){
+        String privateAPIEndpoint = System.getenv("apiGatewayIdPrivate");
+        if (privateAPIEndpoint == null) {
+            throw new IllegalArgumentException("Environment variable PRIVATE API endpoint is not set");
+        }
+        LOGGER.info("privateAPIEndpoint =>"+privateAPIEndpoint);
+        return  "https://" + privateAPIEndpoint + ".execute-api.eu-west-2.amazonaws.com/build";
     }
 
     private String getClaimsForUser(String baseUrl, String criId, int userDataRowNumber)
@@ -88,33 +115,6 @@ public class FraudAPIStepDefs {
                         .build();
 
         return sendHttpRequest(request).body();
-    }
-
-    @When("user sends a POST request to session end point")
-    public void user_sends_a_post_request_to_session_end_point()
-            throws IOException, InterruptedException {
-        // Write code here that turns the phrase above into concrete actions
-        LOGGER.info("getPrivateAPIEndpoint() ==> "+ getPrivateAPIEndpoint());
-        HttpRequest request =
-                HttpRequest.newBuilder()
-                        .uri(URI.create(getPrivateAPIEndpoint() + "/session"))
-                        .setHeader("Accept", "application/json")
-                        .setHeader("Content-Type", "application/json")
-//                        .setHeader("X-Forwarded-For", "192.168.0.1")
-                        .POST(HttpRequest.BodyPublishers.ofString(SESSION_REQUEST_BODY))
-                        .build();
-        String sessionResponse = sendHttpRequest(request).body();
-        LOGGER.info("sessionResponse = " + sessionResponse);
-        Map<String, String> deserialisedResponse =
-                objectMapper.readValue(sessionResponse, new TypeReference<>() {
-                });
-        SESSION_ID = deserialisedResponse.get("session_id");
-    }
-
-    @Then("user gets a session-id")
-    public void user_gets_a_session_id() {
-        LOGGER.info("SESSION_ID = " + SESSION_ID);
-        assertTrue(StringUtils.isNotBlank(SESSION_ID));
     }
 
     private HttpResponse<String> sendHttpRequest(HttpRequest request)

--- a/src/test/resources/features/FraudCRIAPI.feature
+++ b/src/test/resources/features/FraudCRIAPI.feature
@@ -1,0 +1,8 @@
+@fraud_CRI_API
+Feature: Fraud CRI API
+
+  @intialJWT_happy_path @build
+  Scenario: Acquire initial JWT (STUB)
+    Given user has the user identity in the form of a signed JWT string
+#    When user sends a POST request to session end point
+#    Then user gets a session-id


### PR DESCRIPTION
This consists of the automation test for https://govukverify.atlassian.net/browse/LIME-116 "Add endpoint to IPV Core stub to allow testers to acquire the initial JWT"
Please note that the stub endpoints /backend/generateInitialClaimSet and /backend/createSessionRequest have been tested but the session endpoint could not be tested locally and will need to be confirmed in the environments in the near future.

The following feature file and the step definition file have been added :
src/test/resources/features/FraudCRIAPI.feature
src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java