### PR TITLE
Driving licence unhandling error

### DIFF
--- a/src/test/java/gov/di_ipv_fraud/pages/DLUnrecoverableErrorPageObject.java
+++ b/src/test/java/gov/di_ipv_fraud/pages/DLUnrecoverableErrorPageObject.java
@@ -1,0 +1,73 @@
+package gov.di_ipv_fraud.pages;
+
+import gov.di_ipv_fraud.service.ConfigurationService;
+import gov.di_ipv_fraud.utilities.BrowserUtils;
+import gov.di_ipv_fraud.utilities.Driver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+
+import java.util.logging.Logger;
+
+import static gov.di_ipv_fraud.pages.Headers.IPV_CORE_STUB;
+
+public class DLUnrecoverableErrorPageObject extends UniversalSteps {
+
+    private static final Logger LOGGER = Logger.getLogger(DLUnrecoverableErrorPageObject.class.getName());
+
+    @FindBy(xpath = "//*[@id=\"main-content\"]/p/a")
+    public WebElement visitCredentialIssuers;
+
+   @FindBy(xpath = "//*[@id=\"main-content\"]/p[5]/a/input")
+    public WebElement drivingLicenceCRIDev;
+
+    @FindBy(xpath = "//*[@id=\"main-content\"]/form[2]/div/button")
+    public WebElement goToDLCRIButton;
+
+    @FindBy(id = "rowNumber")
+    public WebElement selectRow;
+
+    @FindBy(id = "header")
+    public WebElement errorTitle;
+
+   public void navigateToDrivingLicenceCRIDev()
+    {
+        visitCredentialIssuers.click();
+        BrowserUtils.waitForPageToLoad(100);
+        drivingLicenceCRIDev.click();
+        BrowserUtils.waitForPageToLoad(100);
+    }
+
+    public void searchForUATUser(String number) {
+        assertURLContains("credential-issuer?cri=driving-licence");
+        selectRow.sendKeys(number);
+    }
+
+    public void navigateToDrivingLicenceCRI() {
+        goToDLCRIButton.click();
+    }
+
+   public void errorPageURLValidation() {
+
+       String actualTitle = Driver.get().getTitle();
+       String expTitle = "Sorry, there is a problem – – GOV.UK";
+       if (actualTitle.equals(expTitle)) {
+
+           System.out.println(actualTitle + " is same");
+       } else {
+
+           System.out.println(actualTitle + " is not same");
+       }
+   }
+
+   public void validateErrorPageHeading() {
+       String expectedText = "Sorry, there is a problem";
+       String actualText = errorTitle.getText();
+       if (actualText.equals(expectedText)) {
+           System.out.println(actualText + " is same");
+       } else {
+           System.out.println(actualText + " is not same");
+       }
+   }
+}
+

--- a/src/test/java/gov/di_ipv_fraud/pages/DLUnrecoverableErrorPageObject.java
+++ b/src/test/java/gov/di_ipv_fraud/pages/DLUnrecoverableErrorPageObject.java
@@ -70,4 +70,3 @@ public class DLUnrecoverableErrorPageObject extends UniversalSteps {
        }
    }
 }
-

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/DLUnrecoverableErrorStepDefs.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/DLUnrecoverableErrorStepDefs.java
@@ -1,0 +1,30 @@
+package gov.di_ipv_fraud.step_definitions;
+
+import gov.di_ipv_fraud.pages.DLUnrecoverableErrorPageObject;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class DLUnrecoverableErrorStepDefs extends DLUnrecoverableErrorPageObject
+{
+   @When("I navigate to User for Driving Licence CRI dev Page")
+   public void i_navigate_to_user_for_driving_licence_cri_dev_page() {
+      navigateToDrivingLicenceCRIDev();
+   }
+
+   @And("I click Go to Driving Licence CRI dev button")
+   public void i_click_go_to_driving_licence_cri_dev_button() {
+      navigateToDrivingLicenceCRI();
+   }
+
+   @Given("I can see the relevant error page with correct title")
+   public void i_can_see_the_relevant_error_page() {
+      errorPageURLValidation();
+   }
+
+   @Then("I can see the heading Sorry there is a error page")
+   public void i_can_see_the_heading_page() {
+      validateErrorPageHeading();
+   }
+}

--- a/src/test/resources/features/UKDrivingLicence/DLUnrecoverableError.feature
+++ b/src/test/resources/features/UKDrivingLicence/DLUnrecoverableError.feature
@@ -11,7 +11,3 @@ Feature: Driving License Test
     And I can see the heading Sorry there is a error page
     And The test is complete and I close the driver
 
-
-
-
-

--- a/src/test/resources/features/UKDrivingLicence/DLUnrecoverableError.feature
+++ b/src/test/resources/features/UKDrivingLicence/DLUnrecoverableError.feature
@@ -1,0 +1,17 @@
+Feature: Driving License Test
+
+ Background: @happy_path @localhost8085
+    Given I navigate to the IPV Core Stub
+    When I navigate to User for Driving Licence CRI dev Page
+    Then I search for Driving Licence user number 5 in the Experian table
+    And I click Go to Driving Licence CRI dev button
+
+  Scenario: Check the Unrecoverable error page
+    Given I can see the relevant error page with correct title
+    And I can see the heading Sorry there is a error page
+    And The test is complete and I close the driver
+
+
+
+
+


### PR DESCRIPTION
Covered the test in Local dev : http://localhost:8085/ 

Environment Variable:
STACK_NAME=localstack;contraindicationMappings=unused;FraudTableName=unused;redirectUri=https://dev-danh-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?i=kPassport;clientId=ipv-core;apiBaseUrl=https://byhkc7xsk3.execute-api.eu-west-2.amazonaws.com/build/;coreStubUrl=https://localhost:8085;coreStubUsername=user;coreStubPassword=qTdrBchPGyt2bxaCr3ve;passportCriUrl=https://development-di-ipv-cri-uk-passport-front.london.cloudapps.digitalexport ;orchestratorStubUrl=https://staging-di-ipv-orchestrator-stub.london.cloudapps.digital/;ENVIRONMENT=local ;httpsEnabled=no

