### PR TITLE
Lime 225 implement local allure reporting solution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
 	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
 	id "org.sonarqube"
 	id "com.diffplug.spotless"
+	id "io.qameta.allure" version "2.10.0"
+
 }
 
 defaultTasks 'clean', 'spotlessApply', 'build'
@@ -45,6 +47,10 @@ repositories {
 dependencies {
 	aws platform('software.amazon.awssdk:bom:2.17.191')
 	kms "software.amazon.awssdk:kms"
+
+	implementation 'io.qameta.allure:allure-maven:2.11.2'
+	implementation group: 'io.qameta.allure', name: 'allure-cucumber7-jvm', version: '2.18.1'
+	implementation 'com.github.automatedowl:allure-environment-writer:1.0.0'
 
 	implementation "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}"
 	implementation "com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}"
@@ -135,6 +141,7 @@ task cucumber() {
 			args = [
 				'--plugin',
 				'pretty',
+				'--plugin', 'io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm',
 				'--tags',
 				"${tags}",
 				'--glue',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  allure:
+    image: "frankescobar/allure-docker-service"
+    environment:
+      KEEP_HISTORY: 1
+      SERVER_URL: "http://my-domain.com/allure-docker-service/latest-report"
+    ports:
+      - "5050:5050"
+    volumes:
+      - ${PWD}/target/allure-results:/app/allure-results
+      - ${PWD}/target/allure-reports:/app/default-reports

--- a/dockerServiceStart.bash
+++ b/dockerServiceStart.bash
@@ -1,0 +1,12 @@
+#docker rm -f $(docker ps -a -q)
+#
+#docker run -p 5050:5050 -e CHECK_RESULTS_EVERY_SECONDS=NONE -e KEEP_HISTORY=1 \
+#-v ${PWD}/target/allure-results:/app/allure-results \
+#-v ${PWD}/target/allure-reports:/app/default-reports \
+#frankescobar/allure-docker-service
+
+result="$(curl -s 'http://localhost:5050/allure-docker-service/emailable-report/render?project_id=default')"
+echo "result: '$result'"
+
+#curl -s 'http://localhost:5050/allure-docker-service/clean-results?project_id=default'
+#curl -s 'http://localhost:5050/allure-docker-service/clean-history?project_id=default'

--- a/src/test/java/gov/di_ipv_fraud/runners/TestRunner.java
+++ b/src/test/java/gov/di_ipv_fraud/runners/TestRunner.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         publish = true,
+        plugin = "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm",
         features = "src/test/resources/features",
         glue = "gov/di_ipv_fraud/step_definitions",
         dryRun = false)

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
@@ -15,7 +15,7 @@ import static com.github.automatedowl.tools.AllureEnvironmentWriter.allureEnviro
 
 public class Hooks {
 
-    @Before("@happy_DVLA")
+    @Before("@DVLADrivingLicence_test")
     public void setUp() {
         Capabilities capabilities = ((RemoteWebDriver) Driver.get()).getCapabilities();
         allureEnvironmentWriter(
@@ -26,7 +26,7 @@ public class Hooks {
                         .build());
     }
 
-    @After("@happy_DVLA")
+    @After("@DVLADrivingLicence_test")
     public void onFailure(Scenario scenario) {
         if (scenario.isFailed()) {
             Allure.addAttachment("Screenshot", new ByteArrayInputStream(((TakesScreenshot) Driver.get()).getScreenshotAs(OutputType.BYTES)));

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
@@ -2,23 +2,35 @@ package gov.di_ipv_fraud.step_definitions;
 
 import com.google.common.collect.ImmutableMap;
 import gov.di_ipv_fraud.utilities.Driver;
+import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import io.qameta.allure.Allure;
+import java.io.ByteArrayInputStream;
 import static com.github.automatedowl.tools.AllureEnvironmentWriter.allureEnvironmentWriter;
 
 public class Hooks {
 
-    @Before("@happy_passport")
+    @Before("@happy_DVLA")
     public void setUp() {
         Capabilities capabilities = ((RemoteWebDriver) Driver.get()).getCapabilities();
         allureEnvironmentWriter(
                 ImmutableMap.<String, String>builder()
                         .put("Browser", capabilities.getBrowserName())
                         .put("Browser Version", capabilities.getBrowserVersion())
-                        .put("Environment", System.getenv("ENV"))
+//                        .put("Environment", System.getenv("ENV"))
                         .build());
+    }
+
+    @After("@happy_DVLA")
+    public void onFailure(Scenario scenario) {
+        if (scenario.isFailed()) {
+            Allure.addAttachment("Screenshot", new ByteArrayInputStream(((TakesScreenshot) Driver.get()).getScreenshotAs(OutputType.BYTES)));
+        }
     }
 
 }

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/Hooks.java
@@ -1,0 +1,24 @@
+package gov.di_ipv_fraud.step_definitions;
+
+import com.google.common.collect.ImmutableMap;
+import gov.di_ipv_fraud.utilities.Driver;
+import io.cucumber.java.Before;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import io.qameta.allure.Allure;
+import static com.github.automatedowl.tools.AllureEnvironmentWriter.allureEnvironmentWriter;
+
+public class Hooks {
+
+    @Before("@happy_passport")
+    public void setUp() {
+        Capabilities capabilities = ((RemoteWebDriver) Driver.get()).getCapabilities();
+        allureEnvironmentWriter(
+                ImmutableMap.<String, String>builder()
+                        .put("Browser", capabilities.getBrowserName())
+                        .put("Browser Version", capabilities.getBrowserVersion())
+                        .put("Environment", System.getenv("ENV"))
+                        .build());
+    }
+
+}

--- a/src/test/resources/allure.properties
+++ b/src/test/resources/allure.properties
@@ -1,0 +1,2 @@
+allure.results.directory=target/allure-results
+allure.link.tms.pattern=https://govukverify.atlassian.net/browse/{}

--- a/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -8,7 +8,7 @@ Feature: Driving Licence Test
     And I click on DVLA radio button and Continue
     And I should be on `Enter your details exactly as they appear on your UK driving licence` page
 
-  @DVLADrivingLicence_test @build @happy_DVLA @tmsLink=LIME-178
+  @DVLADrivingLicence_test @build @happy_DVLA @tmsLink=LIME-165
   Scenario Outline:  DVLA Driving Licence details page happy path
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -19,7 +19,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyPeter   |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectDrivingLicenceNumber
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -32,7 +32,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path when licence number date format does not match with User's Date Of Birth
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -43,7 +43,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectDateOfBirth
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -54,7 +54,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectDateOfBirth |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectFirstName
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -67,7 +67,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectFirstName|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectLastName
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -80,7 +80,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |IncorrectLastName|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectIssueDate
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -93,7 +93,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectIssueDate|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectValidToDate
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -106,7 +106,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectValidToDate|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectIssueNumber
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -119,7 +119,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectIssueNumber|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectPostcode
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -132,7 +132,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectPostcode|
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-167
   Scenario Outline: DVLA Driving Licence Retry Test Happy Path
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -146,7 +146,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyPeter |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-167
   Scenario Outline: DVLA Driving Licence User failed second attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -160,7 +160,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-167
   Scenario: DVLA Driving Licence User cancels after failed first attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -170,14 +170,14 @@ Feature: Driving Licence Test
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-167
   Scenario: DVLA Driving Licence User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @tmsLink=LIME-167
   Scenario: DVLA Driving Licence User cancels before first attempt via I do not have a UK driving licence route
     Given User click on ‘Back' Link
     When User click on I do not have a UK driving licence radio button

--- a/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -8,7 +8,7 @@ Feature: Driving Licence Test
     And I click on DVLA radio button and Continue
     And I should be on `Enter your details exactly as they appear on your UK driving licence` page
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @happy_DVLA @tmsLink=LIME-178
   Scenario Outline:  DVLA Driving Licence details page happy path
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue

--- a/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -8,7 +8,7 @@ Feature: Driving Licence Test
     And I click on DVLA radio button and Continue
     And I should be on `Enter your details exactly as they appear on your UK driving licence` page
 
-  @DVLADrivingLicence_test @build @happy_DVLA @tmsLink=LIME-165
+  @DVLADrivingLicence_test @build @tmsLink=LIME-165
   Scenario Outline:  DVLA Driving Licence details page happy path
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue


### PR DESCRIPTION
This pull request has the changes done as part of this ticket 
 Implement the local Allure reporting solution outlined in the Automated Test Reporting https://govukverify.atlassian.net/browse/LIME-225
 
Updated the DVLA tests with tmsLink tags
Updated plugins and dependencies for Allure Reporting
Added a Hooks class to include the environment writer logic
Created allure.properties file in our resources directory (src/test/resources)
Added docker-compose.yml file and dockerServiceStart.bash