### PR TITLE
GenerateVCFirstAttempt

### DIFF
--- a/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -395,6 +395,22 @@ public class FraudPageObject extends UniversalSteps {
         assertEquals(fraudScore, score);
     }
 
+    public void documentNumberInVC(String documentNumber) throws IOException {
+        String result = JSONPayload.getText();
+        LOGGER.info("result = " + result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode evidenceNode = vcNode.get("drivingPermit");
+
+        ObjectReader objectReader =
+                new ObjectMapper().readerFor(new TypeReference<List<JsonNode>>() {});
+        List<JsonNode> evidence = objectReader.readValue(evidenceNode);
+
+        String licenceNumber = evidence.get(0).get("documentNumber").asText();
+        assertEquals(documentNumber, licenceNumber);
+    }
+
     public void goToPageWithTitle(String title) {
         pagetTitle.getText();
     }

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/DVLAAndDVADrivingLicenceSteps.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/DVLAAndDVADrivingLicenceSteps.java
@@ -11,7 +11,7 @@ import org.junit.Assert;
 
 import java.io.IOException;
 
-public class DVLAAndDVADrivingLicenceSteps extends DrivingLicencePageObject {
+public class DVLAAndDVADrivingLicenceSteps extends DrivingLicencePageObject  {
 
     @When("User enters data as a {}")
     public void user_enters_and(DrivingLicenceSubject drivingLicenceSubject) {
@@ -112,4 +112,15 @@ public class DVLAAndDVADrivingLicenceSteps extends DrivingLicencePageObject {
     public void userClickOnBackLink() {
         back.click();
     }
+
+    @When("User clicks on continue again")
+    public void user_clicks_on_continue_again() {
+        Continue.click();
+    }
+
+    @And("^JSON response should contain documentNumber (.*) same as given Driving Licence$")
+    public void errorInJsonResponse(String documentNumber) throws IOException {
+        new FraudPageObject().documentNumberInVC(documentNumber);
+    }
+
 }

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/DVLAAndDVADrivingLicenceSteps.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/DVLAAndDVADrivingLicenceSteps.java
@@ -113,11 +113,6 @@ public class DVLAAndDVADrivingLicenceSteps extends DrivingLicencePageObject  {
         back.click();
     }
 
-    @When("User clicks on continue again")
-    public void user_clicks_on_continue_again() {
-        Continue.click();
-    }
-
     @And("^JSON response should contain documentNumber (.*) same as given Driving Licence$")
     public void errorInJsonResponse(String documentNumber) throws IOException {
         new FraudPageObject().documentNumberInVC(documentNumber);

--- a/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -14,6 +14,7 @@ Feature: DVA Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
+    And JSON response should contain documentNumber 55667788 same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject             |
@@ -38,6 +39,7 @@ Feature: DVA Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON response should contain documentNumber 88776655 same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject      |
@@ -174,31 +176,6 @@ Feature: DVA Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
-
-  @DVADrivingLicence_test @build
-  Scenario Outline:  DVA Driving Licence Generate VC with valid DL number and save in attempt 1 happy path
-    Given User enters DVA data as a <DVADrivingLicenceSubject>
-    When User clicks on continue
-    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON response should contain documentNumber 55667788 same as given Driving Licence
-    And The test is complete and I close the driver
-    Examples:
-      |DVADrivingLicenceSubject             |
-      |DVADrivingLicenceSubjectHappyBilly     |
-
-  @DVADrivingLicence_test @build
-  Scenario Outline:  DVA Driving Licence Generate VC with invalid DL number and save in attempt 2 unhappy path
-    Given User enters DVA data as a <DVADrivingLicenceSubject>
-    When User clicks on continue
-    Then Proper error message for Could not find your details is displayed
-    Then User clicks on continue again
-    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON response should contain documentNumber 88776655 same as given Driving Licence
-    And The test is complete and I close the driver
-    Examples:
-      |DVADrivingLicenceSubject |
-      |IncorrectDVADrivingLicenceNumber |
-
 
   @DVADrivingLicence_test @build
   Scenario Outline:  DVA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path

--- a/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -174,3 +174,40 @@ Feature: DVA Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
+
+  @DVADrivingLicence_test @build
+  Scenario Outline:  DVA Driving Licence Generate VC with valid DL number and save in attempt 1 happy path
+    Given User enters DVA data as a <DVADrivingLicenceSubject>
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber 55667788 same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DVADrivingLicenceSubject             |
+      |DVADrivingLicenceSubjectHappyBilly     |
+
+  @DVADrivingLicence_test @build
+  Scenario Outline:  DVA Driving Licence Generate VC with invalid DL number and save in attempt 2 unhappy path
+    Given User enters DVA data as a <DVADrivingLicenceSubject>
+    When User clicks on continue
+    Then Proper error message for Could not find your details is displayed
+    Then User clicks on continue again
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber 88776655 same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DVADrivingLicenceSubject |
+      |IncorrectDVADrivingLicenceNumber |
+
+
+  @DVADrivingLicence_test @build
+  Scenario Outline:  DVA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path
+    Given User enters DVA data as a <DVADrivingLicenceSubject>
+    When User clicks on continue
+    When User click on ‘prove your identity another way' Link
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber 88776655 same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DVADrivingLicenceSubject           |
+      | IncorrectDVADrivingLicenceNumber     |

--- a/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -14,6 +14,7 @@ Feature: Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
+    And JSON response should contain documentNumber PARKE610112PBFGH same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |
@@ -27,6 +28,7 @@ Feature: Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON response should contain documentNumber PARKE610112PBFGI same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject      |
@@ -184,30 +186,6 @@ Feature: Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
-
-  @DVLADrivingLicence_test @build
-  Scenario Outline:  DVLA Driving Licence Generate VC with valid DL number and save in attempt 1 happy path
-    Given User enters data as a <DrivingLicenceSubject>
-    When User clicks on continue
-    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON response should contain documentNumber PARKE610112PBFGH same as given Driving Licence
-    And The test is complete and I close the driver
-    Examples:
-      |DrivingLicenceSubject             |
-      |DrivingLicenceSubjectHappyPeter   |
-
-  @DVLADrivingLicence_test @build
-  Scenario Outline:  DVLA Driving Licence Generate VC with invalid DL number and save in attempt 2 unhappy path
-    Given User enters data as a <DrivingLicenceSubject>
-    When User clicks on continue
-    Then Proper error message for Could not find your details is displayed
-    Then User clicks on continue again
-    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON response should contain documentNumber PARKE610112PBFGI same as given Driving Licence
-    And The test is complete and I close the driver
-    Examples:
-      |DrivingLicenceSubject             |
-      | IncorrectDrivingLicenceNumber    |
 
   @DVLADrivingLicence_test @build
   Scenario Outline:  DVLA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path

--- a/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -184,3 +184,39 @@ Feature: Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
+
+  @DVLADrivingLicence_test @build
+  Scenario Outline:  DVLA Driving Licence Generate VC with valid DL number and save in attempt 1 happy path
+    Given User enters data as a <DrivingLicenceSubject>
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber PARKE610112PBFGH same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      |DrivingLicenceSubjectHappyPeter   |
+
+  @DVLADrivingLicence_test @build
+  Scenario Outline:  DVLA Driving Licence Generate VC with invalid DL number and save in attempt 2 unhappy path
+    Given User enters data as a <DrivingLicenceSubject>
+    When User clicks on continue
+    Then Proper error message for Could not find your details is displayed
+    Then User clicks on continue again
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber PARKE610112PBFGI same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      | IncorrectDrivingLicenceNumber    |
+
+  @DVLADrivingLicence_test @build
+  Scenario Outline:  DVLA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path
+    Given User enters data as a <DrivingLicenceSubject>
+    When User clicks on continue
+    When User click on ‘prove your identity another way' Link
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON response should contain documentNumber PARKE610112PBFGI same as given Driving Licence
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      | IncorrectDrivingLicenceNumber    |


### PR DESCRIPTION
DVLA Driving Licence Generate VC with valid DL number and save  save check the document number is same as given Driving Licence in attempt 1 happy path
DVLA Driving Licence Generate VC with invalid DL number and save check the document number is same as given Driving Licence in attempt 2 unhappy path
DVLA Driving Licence Generate VC with invalid DL number and save check the document number is same as given Driving Licence prove in another way unhappy path
DVA Driving Licence Generate VC with valid DL number and save  save check the document number is same as given Driving Licence in attempt 1 happy path
DVA Driving Licence Generate VC with invalid DL number and save check the document number is same as given Driving Licence in attempt 2 unhappy path
DVA Driving Licence Generate VC with invalid DL number and save check the document number is same as given Driving Licence prove in another way unhappy path

