### PR TITLE
Refactored the Fraud CRI tests to remove duplicates

### DIFF
--- a/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import gov.di_ipv_fraud.service.ConfigurationService;
+import gov.di_ipv_fraud.utilities.BrowserUtils;
 import gov.di_ipv_fraud.utilities.Driver;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
@@ -167,6 +168,21 @@ public class FraudPageObject extends UniversalSteps {
             Driver.get().get("http://" + coreStubUrl);
         }
         waitForTextToAppear(IPV_CORE_STUB);
+    }
+
+    public void navigateToFraudCRIOnTestEnv() {
+        visitCredentialIssuers.click();
+        String fraudCRITestEnvironment = configurationService.getFraudCRITestEnvironment();
+        LOGGER.info("fraudCRITestEnvironment = " + fraudCRITestEnvironment);
+        if (fraudCRITestEnvironment.equalsIgnoreCase("Build")) {
+            fraudCRIBuild.click();
+        } else if (fraudCRITestEnvironment.equalsIgnoreCase("Staging")) {
+            fraudCRIStaging.click();
+        } else if (fraudCRITestEnvironment.equalsIgnoreCase("Integration")) {
+            fraudCRIIntegration.click();
+        } else {
+            LOGGER.info("No test environment is set");
+        }
     }
 
     public void navigateToFraudCRI(String environment) {

--- a/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
+++ b/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
@@ -85,4 +85,12 @@ public class ConfigurationService {
     public String gethttpsEnabled() {
         return httpsEnabled;
     }
+
+    public static String getFraudCRITestEnvironment() {
+        String fraudCRITestEnvironment = System.getenv("FRAUD_CRI_TEST_ENVIRONMENT");
+        if (fraudCRITestEnvironment == null) {
+            throw new IllegalArgumentException("Environment variable FRAUD_CRI_TEST_ENVIRONMENT is not set");
+        }
+        return fraudCRITestEnvironment;
+    }
 }

--- a/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -25,6 +25,11 @@ public class FraudStepDefs extends FraudPageObject {
         navigateToFraudCRI(environment);
     }
 
+    @And("^I click the Fraud CRI for the testEnvironment$")
+    public void navigateToFraudOnTestEnv() {
+        navigateToFraudCRIOnTestEnv();
+    }
+
     @Then("^I search for user number (.*) in the Experian table$")
     public void userSearch(String number) {
         searchForUATUser(number);

--- a/src/test/resources/features/FraudCRI.feature
+++ b/src/test/resources/features/FraudCRI.feature
@@ -1,149 +1,48 @@
 @fraud_CRI
 Feature: Fraud CRI
 
-  @happy_path @build-fraud
+  @happy_path @build-fraud @staging @integration
   Scenario: User Journey Happy Path (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
+    And I click the Fraud CRI for the testEnvironment
     Then I search for user number 12 in the Experian table
     And I navigate to the verifiable issuer to check for a Valid response from experian
     And The test is complete and I close the driver
 
-  @happy_path @staging
-  Scenario: User Journey Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    Then I search for user number 12 in the Experian table
-    And I navigate to the verifiable issuer to check for a Valid response from experian
-    And The test is complete and I close the driver
-
-  @happy_path @integration
-  Scenario: User Journey Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
-    Then I search for user number 12 in the Experian table
-    And I navigate to the verifiable issuer to check for a Valid response from experian
-    And The test is complete and I close the driver
-
-  @unhappy_path @build-fraud
+  @unhappy_path @build-fraud @staging @integration
   Scenario: User Journey Unhappy Path (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
+    And I click the Fraud CRI for the testEnvironment
     Then I search for user number 14 in the Experian table
     And I navigate to the verifiable issuer to check for a Invalid response from experian
     And The test is complete and I close the driver
 
-  @unhappy_path @staging
-  Scenario: User Journey Unhappy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    Then I search for user number 14 in the Experian table
-    And I navigate to the verifiable issuer to check for a Invalid response from experian
-    And The test is complete and I close the driver
-
-  @unhappy_path @integration
-  Scenario: User Journey Unhappy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
-    Then I search for user number 14 in the Experian table
-    And I navigate to the verifiable issuer to check for a Invalid response from experian
-    And The test is complete and I close the driver
-
-  @external_links @build-fraud
+  @external_links @build-fraud @staging @integration
   Scenario Outline: User Navigates To Experian/Privacy Policy
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
+    And I click the Fraud CRI for the testEnvironment
     Then I search for user number 12 in the Experian table
     Then I navigate to <page> and assert I have been directed correctly
     And The test is complete and I close the driver
-
     Examples:
       | page           |
       | Experian       |
       | Privacy Policy |
 
-  @external_links @staging
-  Scenario Outline: User Navigates To Experian/Privacy Policy
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    Then I search for user number 12 in the Experian table
-    Then I navigate to <page> and assert I have been directed correctly
-    And The test is complete and I close the driver
-
-    Examples:
-      | page           |
-      | Experian       |
-      | Privacy Policy |
-
-  @external_links @integration
-  Scenario Outline: User Navigates To Experian/Privacy Policy
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
-    Then I search for user number 12 in the Experian table
-    Then I navigate to <page> and assert I have been directed correctly
-    And The test is complete and I close the driver
-
-    Examples:
-      | page           |
-      | Experian       |
-      | Privacy Policy |
-
-  @userSearch_by_userName_happyPath @build-fraud
+  @userSearch_by_userName_happyPath @build-fraud @staging @integration
   Scenario: User Search By UserName User Journey Happy Path (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
+    And I click the Fraud CRI for the testEnvironment
     When I search for user name Linda Duff in the Experian table
     And I click on Go to Fraud CRI link
     Then I navigate to the verifiable issuer to check for a Valid response from experian
     And JSON payload should contain user's name
     And The test is complete and I close the driver
 
-  @userSearch_by_userName_happyPath @staging
-  Scenario: User Search By UserName User Journey Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    When I search for user name Linda Duff in the Experian table
-    And I click on Go to Fraud CRI link
-    Then I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain user's name
-    And The test is complete and I close the driver
-
-  @userSearch_by_userName_happyPath @integration
-  Scenario: User Search By UserName User Journey Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
-    When I search for user name Linda Duff in the Experian table
-    And I click on Go to Fraud CRI link
-    Then I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain user's name
-    And The test is complete and I close the driver
-
-  @Spinner_icon_within_Fraud_CRI_screen @build-fraud
+  @Spinner_icon_within_Fraud_CRI_screen @build-fraud @staging @integration
   Scenario: User is presented with a spinner when clicking on the Continue button in the Fraud CRI screen (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
-    And I search for user number 12 in the Experian table
-    And I navigate to the page We need to check your details
-    When I check Continue button is enabled and click on the Continue button
-    Then I navigate to Verifiable Credentials page
-    And I check for a Valid response from experian
-    And The test is complete and I close the driver
-
-  @Spinner_icon_within_Fraud_CRI_screen @staging
-  Scenario: User is presented with a spinner when clicking on the Continue button in the Fraud CRI screen (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    And I search for user number 12 in the Experian table
-    And I navigate to the page We need to check your details
-    When I check Continue button is enabled and click on the Continue button
-    Then I navigate to Verifiable Credentials page
-    And I check for a Valid response from experian
-    And The test is complete and I close the driver
-
-  @Spinner_icon_within_Fraud_CRI_screen @integration
-  Scenario: User is presented with a spinner when clicking on the Continue button in the Fraud CRI screen (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
+    And I click the Fraud CRI for the testEnvironment
     And I search for user number 12 in the Experian table
     And I navigate to the page We need to check your details
     When I check Continue button is enabled and click on the Continue button
@@ -171,38 +70,10 @@ Feature: Fraud CRI
     And JSON response should contain error details and status code as 302
     And The test is complete and I close the driver
 
-  @edituser_happyPath @build-fraud
+  @edituser_happyPath @build-fraud @staging @integration
   Scenario: Edit User Happy Path (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
-    And I search for user name Linda Duff in the Experian table
-    When I click on Edit User link
-    And I am on Edit User page
-    And I enter Test 45 in the House name field
-    And I clear existing House number
-    And I enter 455 in the House number field
-    Then I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain user's House name as Test 45 and House number as 455
-    And The test is complete and I close the driver
-
-  @edituser_happyPath @staging
-  Scenario: Edit User Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
-    And I search for user name Linda Duff in the Experian table
-    When I click on Edit User link
-    And I am on Edit User page
-    And I enter Test 45 in the House name field
-    And I clear existing House number
-    And I enter 455 in the House number field
-    Then I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain user's House name as Test 45 and House number as 455
-    And The test is complete and I close the driver
-
-  @edituser_happyPath @integration
-  Scenario: Edit User Happy Path (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
+    And I click the Fraud CRI for the testEnvironment
     And I search for user name Linda Duff in the Experian table
     When I click on Edit User link
     And I am on Edit User page
@@ -232,7 +103,7 @@ Feature: Fraud CRI
     And The test is complete and I close the driver
 
   # User with surname CI6 will return the U015 code and will return CI as P01 in the VC
-  @pep_test_all_users @build-fraud @test
+  @pep_test_all_users @build-fraud
   Scenario Outline: Edit User Happy Path with pep CI (STUB)
     Given I navigate to the IPV Core Stub
     And I click the Fraud CRI for the Build environment
@@ -254,7 +125,6 @@ Feature: Fraud CRI
       | ANTHONY CI6           | 17/02/1963     | P01  |    2  |
       | ANTHONY CI4           | 17/02/1963     | T03  |    0  |
       | ANTHONY NO_FILE_35    | 17/02/1963     |      |    1  |
-
 
   @pep_test_all_users @staging
   Scenario Outline: Edit User Happy Path with pep CI (STUB)
@@ -303,30 +173,30 @@ Feature: Fraud CRI
       | DIPTI STUPPART          | 26/01/1989     | P02 |   2   |
       | JAMALA BROWER           | 27/10/1963     | P02 |   2   |
 
-  @Search_user_with_MissingDetails_and_EditUser_Unhappypath
-  Scenario Outline: Search for user with missing details and edit user UnHappy Path (STUB)'
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the <environment> environment
-    And I search for user name Richard Gillis in the Experian table
-    When I click on Edit User link
-    And I clear the postcode
-    And I clear existing House number
-    And I click on Go to Fraud CRI link after Edit
-    Then I navigate to the verifiable issuer to check for a Invalid response from experian
-    And JSON response should contain error details and status code as 302
-    And Validate User navigation back to core for invalid users
-    And The test is complete and I close the driver
+#  @Search_user_with_MissingDetails_and_EditUser_Unhappypath
+#  Scenario Outline: Search for user with missing details and edit user UnHappy Path (STUB)'
+#    Given I navigate to the IPV Core Stub
+#    And I click the Fraud CRI for the <environment> environment
+#    And I search for user name Richard Gillis in the Experian table
+#    When I click on Edit User link
+#    And I clear the postcode
+#    And I clear existing House number
+#    And I click on Go to Fraud CRI link after Edit
+#    Then I navigate to the verifiable issuer to check for a Invalid response from experian
+#    And JSON response should contain error details and status code as 302
+#    And Validate User navigation back to core for invalid users
+#    And The test is complete and I close the driver
+#
+#    Examples:
+#      | environment |
+#      | Build       |
+#      | Staging     |
+#      | Integration |
 
-    Examples:
-      | environment |
-      | Build       |
-      | Staging     |
-      | Integration |
-
-  @test_PEP_user_with_multiple_addresses @staging
+  @test_PEP_user_with_multiple_addresses @staging @build-fraud
   Scenario Outline: Edit PEP User with multiple addresses (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
+    And I click the Fraud CRI for the testEnvironment
     And I search for user name LINDA DUFF in the Experian table
     When I click on Edit User link
     Then I am on Edit User page
@@ -346,32 +216,6 @@ Feature: Fraud CRI
     And The test is complete and I close the driver
 
     #Pep is skipped due to zero decision score
-    Examples:
-      | name                    | dob            | ci  | score |
-      | ANTHONY ROBERTS         | 25/06/1959     |     |   1   |
-
-  @test_PEP_user_with_multiple_addresses @build-fraud
-  Scenario Outline: Edit PEP User with multiple addresses (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Build environment
-    And I search for user name LINDA DUFF in the Experian table
-    When I click on Edit User link
-    Then I am on Edit User page
-    And I clear existing Date of Birth
-    And I enter Date of birth as <dob>
-    And I clear existing first name
-    And I clear existing surname
-    And I enter name <name>
-    When I click on Second address
-    And I enter Second address details
-      | housenumber | streetname | townorcity | postcode |
-      | 285         | HIGH STREET| WESTBURY   | BA13 3BN  |
-    And I enter valid to date as 01/01/2021
-    And I submit user updates
-    Then I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain ci <ci> and score <score>
-    And The test is complete and I close the driver
-
     Examples:
       | name                    | dob            | ci  | score |
       | ANTHONY ROBERTS         | 25/06/1959     |     |   1   |

--- a/src/test/resources/features/FraudCRI.feature
+++ b/src/test/resources/features/FraudCRI.feature
@@ -93,15 +93,6 @@ Feature: Fraud CRI
     And JSON payload should contain ci A01 and score 2
     And The test is complete and I close the driver
 
-  @happy_path_with_ci_fraud @integration
-  Scenario: User Journey Happy Path with A01 CI (STUB)
-    Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Integration environment
-    Then I search for user number 34 in the Experian table
-    And I navigate to the verifiable issuer to check for a Valid response from experian
-    And JSON payload should contain ci A01 and score 2
-    And The test is complete and I close the driver
-
   # User with surname CI6 will return the U015 code and will return CI as P01 in the VC
   @pep_test_all_users @build-fraud
   Scenario Outline: Edit User Happy Path with pep CI (STUB)


### PR DESCRIPTION
This is a pull request for https://govukverify.atlassian.net/browse/LIME-163

For all the tests that run across Build, Integration and Staging environments using the same test data, we will now use a new method and will pass the environment info in the environment variables. The duplicate tests have been removed.

For the tests that run only in specific environments OR those that use different test data across different test environments, we will continue to use the existing method where the environment is passed as a parameter in the test step. 